### PR TITLE
Container Image Push

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ To build the application binary, execute:
 make
 ```
 
-In order to build the application conatiner image, run:
+In order to build the application container image, run:
 
 ```sh
 make image

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ Pull upstream container image into local storage. Example:
 imagenie pull alpine:latest
 ```
 
+### `push`
+
+Push image to container registry, for example:
+
+```sh
+imagenie pull alpine:latest
+```
+
+Image also may contain the transport mechanism, adding for instance `docker://` to the image
+argument. Additionally, multiple images can be specified.
+
 ### `reduce`
 
 Compose a new container image (`target-image`), based on `base-image` and `source-image`. Represented
@@ -45,6 +56,7 @@ The following parameters are present on `reduce` sub-command.
 | `entrypoint` | slice   | entrypoint directive for target-image                       |
 | `cmd`        | slice   | command (cmd) directive for target-image                    |
 | `run`        | slice   | command to run in target-image                              |
+| `push`       | bool    | push target-image to container registry                     |
 
 All `slice` typed parameters can be specified several times, and will be accumulated.
 

--- a/cmd/imagenie/pull.go
+++ b/cmd/imagenie/pull.go
@@ -8,12 +8,13 @@ import (
 	"github.com/spf13/viper"
 )
 
-// pullCmd cobra pull sub-command declaration.
+// pullCmd cobra definition for pull sub-command
 var pullCmd = &cobra.Command{
-	Use:    "pull <image>",
-	Short:  "Pull a upstream container image from registry.",
-	PreRun: setLogLevelCmd,
-	RunE:   runPullCmd,
+	Use:          "pull <image> [image]",
+	Short:        "Pull a upstream container image from registry.",
+	PreRun:       setLogLevelCmd,
+	RunE:         runPullCmd,
+	SilenceUsage: true,
 	Long: `### imagenie pull
 
 Download a container image from upstream registry to local storage.

--- a/cmd/imagenie/push.go
+++ b/cmd/imagenie/push.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/otaviof/imagenie/pkg/imagenie"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// pushCmd cobra definition for push sub-command
+var pushCmd = &cobra.Command{
+	Use:          "push <image> [image]",
+	Short:        "Upload a container image to its registry.",
+	PreRun:       setLogLevelCmd,
+	RunE:         runPushCmd,
+	SilenceUsage: true,
+	Long: `### imagenie push
+
+Upload container registry into container registry.
+	`,
+}
+
+// init register sub-command in root.
+func init() {
+	flags := pushCmd.PersistentFlags()
+	if err := viper.BindPFlags(flags); err != nil {
+		panic(err)
+	}
+	rootCmd.AddCommand(pushCmd)
+}
+
+// runPushCmd execute image push, more than one image is accepted
+func runPushCmd(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("a container image must be informed, as last argument")
+	}
+
+	for _, image := range args {
+		m, err := imagenie.NewManager(image, image)
+		if err != nil {
+			return err
+		}
+		if err = m.Push(); err != nil {
+			return err
+		}
+		if err = m.Delete(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/imagenie/manager_test.go
+++ b/pkg/imagenie/manager_test.go
@@ -1,8 +1,10 @@
 package imagenie
 
 import (
+	"fmt"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	is "github.com/containers/image/v5/storage"
@@ -26,6 +28,14 @@ func Test(t *testing.T) {
 	imageRef, err := is.Transport.ParseStoreReference(store, targetImage)
 	t.Logf("image-ref: '%#v'", imageRef)
 	t.Logf("err: '%#v'", err)
+}
+
+func TestManager_ensureTargetImageTransport(t *testing.T) {
+	m := Manager{targetImage: targetImage}
+	imageWithTransport := m.ensureTargetImageTransport()
+	prefix := fmt.Sprintf("%s%s", defaultTransport, transportSeparator)
+	require.True(t, strings.HasPrefix(imageWithTransport, prefix),
+		"target container image should have default transport")
 }
 
 func TestManager_NewManager(t *testing.T) {


### PR DESCRIPTION
## Motivation

When creating images with this helper tool, it should be able to upload images to the container registry.

## Changes

Introducing sub-command `push`, and improving `reduce` to be able to push as well, with `--push` parameter.